### PR TITLE
Fixing issue with tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ module.exports = function markdownItBidi(md) {
 
     const bidi = defaultRenderer => (tokens, idx, opts, env, self) => {
         const token = tokens[idx]
+        const prevToken = tokens[idx - 1]
+        if (token.type === 'th_open' && prevToken.type === "tr_open") {
+            return defaultRenderer(tokens, idx, opts, env, self)
+        }
         token.attrSet('dir', 'auto')
         return defaultRenderer(tokens, idx, opts, env, self)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-bidi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A plugin for Markdown-it to add bidi support",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
The first table cell has `dir="auto"`, this causes the dir attribute of the table element to be ignored, which prevents it from mirroring when the first strong character is RTL.