### PR TITLE
Omit first child of each element

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ module.exports = function markdownItBidi(md) {
     if (token.type === 'th_open' && prevToken.type === 'tr_open') {
       return defaultRenderer(tokens, idx, opts, env, self);
     }
+    // omit this token if this is the first child of an element
+    if (prevToken && rules.includes(prevToken.type) && token.level > prevToken.level) {
+      return defaultRenderer(tokens, idx, opts, env, self);
+    }
     token.attrSet('dir', 'auto');
     return defaultRenderer(tokens, idx, opts, env, self);
   };

--- a/index.test.js
+++ b/index.test.js
@@ -31,3 +31,9 @@ test('Add Bidi support to nested elements', () => {
     md.render('1. item 1\n    1. item 2')
   ).toEqual('<ol dir="auto">\n<li>item 1\n<ol dir="auto">\n<li>item 2</li>\n</ol>\n</li>\n</ol>\n');
 });
+
+test('Omit dir=auto for first children of elements', () => {
+  expect(
+    md.render('> # Heading\n> Some text')
+  ).toEqual('<blockquote dir="auto">\n<h1>Heading</h1>\n<p dir="auto">Some text</p>\n</blockquote>\n');
+});


### PR DESCRIPTION
I have implemented suggested changes based on previous discussions (#26). 
I have used the `token.level` property to detect first child of a block element. Also, I have written a small test in `index.test.js`.

If any change to the code is needed just let me know. 